### PR TITLE
アプリキルしたときにplayernotificationをhide

### DIFF
--- a/src/android/java/PlayerActivity.kt
+++ b/src/android/java/PlayerActivity.kt
@@ -248,6 +248,7 @@ class PlayerActivity : AppCompatActivity(), PlayerControlView.VisibilityListener
 
     override fun onDestroy() {
         super.onDestroy()
+        playerNotificationManager?.setPlayer(null)
         releaseAdsLoader()
     }
 


### PR DESCRIPTION
再生中のまま画面したのボタンでアプリキルしたとき後にもplayernotificationがでちゃったのを修正